### PR TITLE
Add pytest and unit tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,8 @@ dependencies = [
     "streamlit>=1.46.1",
     "yfinance>=0.2.64",
 ]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=8.1"
+]

--- a/tests/test_backtesting.py
+++ b/tests/test_backtesting.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import numpy as np
+
+from backtesting import BacktestEngine
+
+
+def test_calculate_metrics_simple():
+    engine = BacktestEngine()
+    portfolio_values = pd.Series([100, 110, 105, 115, 120])
+    metrics = engine._calculate_metrics(100, 120, portfolio_values, [])
+
+    total_return_expected = 20.0
+    days = len(portfolio_values)
+    years = days / 252
+    annual_return_expected = ((120 / 100) ** (1 / years) - 1) * 100 if years > 0 else 0
+    peak = portfolio_values.expanding().max()
+    drawdown = (portfolio_values - peak) / peak * 100
+    max_drawdown_expected = drawdown.min()
+    returns = portfolio_values.pct_change().dropna()
+    excess_returns = returns - (0.02 / 252)
+    sharpe_ratio_expected = excess_returns.mean() / excess_returns.std() * np.sqrt(252) if excess_returns.std() != 0 else 0
+    volatility_expected = returns.std() * np.sqrt(252) * 100
+
+    assert np.isclose(metrics['total_return'], total_return_expected)
+    assert np.isclose(metrics['annual_return'], annual_return_expected)
+    assert np.isclose(metrics['max_drawdown'], max_drawdown_expected)
+    assert np.isclose(metrics['sharpe_ratio'], sharpe_ratio_expected)
+    assert np.isclose(metrics['volatility'], volatility_expected)
+    assert metrics['num_trades'] == 0

--- a/tests/test_technical_analysis.py
+++ b/tests/test_technical_analysis.py
@@ -1,0 +1,28 @@
+import pandas as pd
+import numpy as np
+import pytest
+
+from technical_analysis import TechnicalAnalysis
+
+
+def test_moving_average_basic():
+    data = pd.DataFrame({'Close': [1, 2, 3, 4, 5]})
+    ta = TechnicalAnalysis(data)
+    result = ta.moving_average(3)
+    expected = pd.Series([np.nan, np.nan, 2.0, 3.0, 4.0])
+    pd.testing.assert_series_equal(result.reset_index(drop=True), expected)
+
+
+def test_rsi_calculation():
+    close_prices = [1, 2, 1, 2, 1]
+    data = pd.DataFrame({'Close': close_prices})
+    ta = TechnicalAnalysis(data)
+    result = ta.rsi(period=2)
+
+    delta = data['Close'].diff()
+    gain = (delta.where(delta > 0, 0)).rolling(window=2).mean()
+    loss = (-delta.where(delta < 0, 0)).rolling(window=2).mean()
+    rs = gain / loss
+    expected = 100 - (100 / (1 + rs))
+
+    pd.testing.assert_series_equal(result.reset_index(drop=True), expected.reset_index(drop=True))


### PR DESCRIPTION
## Summary
- set up pytest dependencies
- write tests for TechnicalAnalysis
- add BacktestEngine metrics tests

## Testing
- `pytest -q` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6868a57db0c88330ac9708b7c7ae9fdc