### PR TITLE
Update docs for DATABASE_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,14 +70,15 @@ The system follows a modular architecture with separate components for different
   - Daily change tracking
 - **Data Storage**: PostgreSQL database with session state backup
 
-### 7. Database Layer (`db_simple.py`)
+### 7. Database Layer (`database.py`)
 - **Purpose**: Persistent data storage and caching
 - **Features**:
   - Stock price data caching
   - Portfolio and trade history storage
   - Backtest results archiving
   - Database management interface
-- **Technology**: PostgreSQL with direct SQL queries
+- **Technology**: SQLAlchemy-based PostgreSQL engine
+- **Note**: `db_simple.py` is included only as a lightweight example.
 
 ## Data Flow
 
@@ -102,6 +103,11 @@ The system follows a modular architecture with separate components for different
 ### Data Sources
 - **Yahoo Finance**: Primary data source for stock prices and market data
 - **PostgreSQL**: Persistent data storage and caching
+
+## Setup
+1. Install the dependencies defined in `pyproject.toml`.
+2. Set the `DATABASE_URL` environment variable with your PostgreSQL connection string, e.g., `postgresql://user:password@localhost:5432/dbname`.
+3. Run the Streamlit app with `streamlit run app.py`.
 
 ## Deployment Strategy
 

--- a/replit.md
+++ b/replit.md
@@ -70,14 +70,15 @@ The system follows a modular architecture with separate components for different
   - Daily change tracking
 - **Data Storage**: PostgreSQL database with session state backup
 
-### 7. Database Layer (`db_simple.py`)
+### 7. Database Layer (`database.py`)
 - **Purpose**: Persistent data storage and caching
 - **Features**:
   - Stock price data caching
   - Portfolio and trade history storage
   - Backtest results archiving
   - Database management interface
-- **Technology**: PostgreSQL with direct SQL queries
+- **Technology**: SQLAlchemy-based PostgreSQL engine
+- **Note**: `db_simple.py` remains as a lightweight example.
 
 ## Data Flow
 
@@ -102,6 +103,11 @@ The system follows a modular architecture with separate components for different
 ### Data Sources
 - **Yahoo Finance**: Primary data source for stock prices and market data
 - **PostgreSQL**: Persistent data storage and caching
+
+## Setup
+1. Install the dependencies defined in `pyproject.toml`.
+2. Configure the `DATABASE_URL` environment variable, for example `postgresql://user:password@localhost:5432/dbname`.
+3. Start the app with `streamlit run app.py`.
 
 ## Deployment Strategy
 


### PR DESCRIPTION
## Summary
- mention `database.py` as the default database layer
- show how to configure `DATABASE_URL` in new setup section
- note that `db_simple.py` is only a lightweight example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6869412e99408330bee14c0c5bfdb91e